### PR TITLE
Improve build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,20 @@ before_install:
   - sudo apt-get install -qq
   - sudo apt-get install -qq libasan0 libboost-system1.55-dev libboost-test1.55-dev libboost-program-options1.55-dev
   - sudo service memcached stop
-install:
-  # clang 3.6, libc++
-  - if [ "$CXX" == "clang++" ]; then sudo apt-get -qq install clang-3.6 clang++-3.6 libstdc++6-4.4-dev; fi
-  - if [ "$CXX" == "clang++" ]; then sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 0; fi
-  - if [ "$CXX" == "clang++" ]; then sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 0; fi
-  - if [ "$CXX" == "clang++" ]; then sudo update-alternatives --set clang /usr/bin/clang-3.6; fi
-  - if [ "$CXX" == "clang++" ]; then sudo update-alternatives --set clang++ /usr/bin/clang++-3.6; fi
-  - if [ "$CXX" == "clang++" ]; then export CXXFLAGS="-stdlib=libstdc++"; fi
-  - if [ "$CXX" == "clang++" ]; then export LDFLAGS="-stdlib=libstdc++"; fi
 
 compiler:
-  - clang
   - gcc
-
+  
+matrix:
+  include:
+    - compiler: clang
+      env: CXXFLAGS="-stdlib=libstdc++" LDFLAGS="-stdlib=libstdc++"
+      install:
+        - sudo apt-get -qq install clang-3.6 clang++-3.6 libstdc++6-4.4-dev
+        - sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 0
+        - sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 0
+        - sudo update-alternatives --set clang /usr/bin/clang-3.6
+        - sudo update-alternatives --set clang++ /usr/bin/clang++-3.6
 script:
   - ./all_build.sh
   - ./run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: cpp
 sudo: required
 dist: trusty
 cache:
-  apt: true
+  - apt
+  - ccache
 os:
 - linux
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,19 @@ else ()
 endif ()
 
 ###########################################################################
+#       CCache configuration
+###########################################################################
+
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Qunused-arguments -fcolor-diagnostics")
+    endif()
+endif(CCACHE_FOUND)
+
+###########################################################################
 #       config.h
 ###########################################################################
 include (CheckCXXSymbolExists)


### PR DESCRIPTION
Split the build matrix more correctly (no more ifs in bash) and enable ccache.
This will also help contributors to develop rapidly because it speeds up compilation time.