### PR TITLE
Travis does not report number of CPUs correctly. Force 2.

### DIFF
--- a/all_build.sh
+++ b/all_build.sh
@@ -3,8 +3,11 @@
 BUILD_CFGS="Debug Release RelWithDebugInfo MinSizeRel AddressSanitizer"
 
 . ./cleanup.sh
-
-[ -r "/proc/cpuinfo" ] && PARALLEL="-j$(grep -c '^processor' /proc/cpuinfo)"
+if [ TRAVIS == "yes" ]; then
+  PARALLEL="-j2"
+else
+  [ -r "/proc/cpuinfo" ] && PARALLEL="-j$(grep -c '^processor' /proc/cpuinfo)"
+fi
 for cfg in ${BUILD_CFGS}; do
   clean_build_files
   echo "Building ${cfg} ..."


### PR DESCRIPTION
Travis dedicates 2 CPU to each build job. The machine itself has 32 CPUs.
This should make the CI build faster.