### PR TITLE
BLD: Cache boost variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,10 @@ configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/src/cachelot/version.h.in" "${CMAKE
 ###########################################################################
 # - boost libraries - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 set (BOOST_MIN_VERSION, "1.53.0")
-set (USED_COMPONENTS unit_test_framework system program_options)
+set (USED_COMPONENTS system program_options)
+if (BUILD_TESTS)
+    set(USED_COMPONENTS ${USED_COMPONENTS} unit_test_framework)
+endif()
 set (Boost_USE_MULTITHREADED ON CACHE BOOL "Use multithreaded Boost")
 set (Boost_USE_STATIC_LIBS ON CACHE BOOL "Use static Boost libraries")
 add_definitions (-DBOOST_ALL_NO_LIB) # disable boost auto-linking feature as it does not work with all compilers
@@ -176,12 +179,14 @@ include_directories (src)
 add_subdirectory (src/cachelot)
 # - - - cachelotd server - - - - - - -
 add_subdirectory (src/server)
+if (BUILD_TESTS)
 # - - - unit tests - - - - - - - - - -
 add_subdirectory (src/unit_test)
-# - - - Benchmarks - - - - - - - - - -
-add_subdirectory (src/benchmark)
 # - - - C API test - - - - - - - - - -
 add_subdirectory (src/test_c_api)
+endif()
+# - - - Benchmarks - - - - - - - - - -
+add_subdirectory (src/benchmark)
 
 
 ###########################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ include_directories (${INCLUDE_DIRECTORIES} ${Boost_INCLUDE_DIRS})
 #       Targets
 ###########################################################################
 message (STATUS "Cachelot setup ...")
+set (NO_SERVER OFF CACHE BOOL "Do not build the server")
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE}")
 set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CMAKE_BUILD_TYPE}")
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CMAKE_BUILD_TYPE}")
@@ -177,8 +178,10 @@ endif ()
 include_directories (src)
 # - - - cachelot library - - - - - - -
 add_subdirectory (src/cachelot)
+if (NOT NO_SERVER)
 # - - - cachelotd server - - - - - - -
 add_subdirectory (src/server)
+endif()
 if (BUILD_TESTS)
 # - - - unit tests - - - - - - - - - -
 add_subdirectory (src/unit_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,8 +146,8 @@ configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/src/cachelot/version.h.in" "${CMAKE
 # - boost libraries - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 set (BOOST_MIN_VERSION, "1.53.0")
 set (USED_COMPONENTS unit_test_framework system program_options)
-set (Boost_USE_MULTITHREADED ON)
-set (Boost_USE_STATIC_LIBS ON)
+set (Boost_USE_MULTITHREADED ON CACHE BOOL "Use multithreaded Boost")
+set (Boost_USE_STATIC_LIBS ON CACHE BOOL "Use static Boost libraries")
 add_definitions (-DBOOST_ALL_NO_LIB) # disable boost auto-linking feature as it does not work with all compilers
 find_package (Boost ${BOOST_MIN_VERSION} COMPONENTS ${USED_COMPONENTS} REQUIRED)
 include_directories (${INCLUDE_DIRECTORIES} ${Boost_INCLUDE_DIRS})

--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,8 @@ Then, vcpkg is ready to be used with Visual Studio and CMake. If the vcpkg insta
 *Note:* The script `build.bat` automatically detect vcpkg installation folder.
 
 ### Run tests or benchmarks ###
-All binaries (main executable, unit tests, etc.) will be in `bin/{build_type}`.
+Tests need to be enabled via `-DBUILD_TESTS=ON`. All binaries (main executable,
+unit tests, etc.) will be in `bin/{build_type}`.
 
 Dedicated test script if available for automatically run the tests:
 


### PR DESCRIPTION
So they can be overridden from the command line. This also makes it easier to integrate with `meson.build` as for example:

```meson
cmake = import('cmake')
opt_var = cmake.subproject_options()
opt_var.add_cmake_defines(
    {'CMAKE_BUILD_TYPE': 'Release', 'Boost_USE_STATIC_LIBS': false, 'NO_SERVER': true},
)

cmcachelot = cmake.subproject('cachelot', options: opt_var)
_deps += cmcachelot.dependency('cachelot')
```

With a simple warp file:

```ini
[wrap-git]
directory=cachelot
url=https://github.com/cachelot/cachelot.git
revision=68520452f6403d928f20f23b2c93dc2f5c346edc
depth=1
method=cmake

[provide]
cachelot=cachelot_dep
```